### PR TITLE
remove "targets" from preset-env

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,14 +1,5 @@
 {
   "presets": [
-    [
-      "@babel/preset-env",
-      {
-        "targets": {
-          "chrome": "40",
-          "safari": "8",
-          "firefox": "40"
-        }
-      }
-    ]
+    "@babel/preset-env"
   ]
 }


### PR DESCRIPTION
Without specifing "targets", @babel/preset-env compiles to ES5